### PR TITLE
Update README.md

### DIFF
--- a/examples/daq_application_opmonlib/README.md
+++ b/examples/daq_application_opmonlib/README.md
@@ -71,7 +71,7 @@ $ kubectl -n monitoring exec -it influxdb-5f875748d6-xx9x6 -- bash
 $ influx
 Connected to http://localhost:8086 version 1.8.6
 InfluxDB shell version: 1.8.6
-$ use database influxdb
+$ use influxdb
 $ show measurements
 name: measurements
 name


### PR DESCRIPTION
Request made after experimenting with the pocket example on a couple of machines.

Correction to one line of instructions (line 74). The current version says that after starting influx you use the command "use database influxdb". The command should be "use influxdb" - if you type "use database influxdb" it will tell you that it can't find the database "database".