### PR TITLE
for now, hardcode TRACE_FILE to be file in shared area

### DIFF
--- a/images/daq_application/cvmfs_import/rebuild_work_area.sh
+++ b/images/daq_application/cvmfs_import/rebuild_work_area.sh
@@ -12,5 +12,5 @@ echo export PATH=$PATH >> run_env.sh
 echo export READOUT_SHARE=$READOUT_SHARE >> run_env.sh
 echo export TIMING_SHARE=$TIMING_SHARE >> run_env.sh
 echo export TRACE_BIN=$TRACE_BIN >> run_env.sh
-echo export TRACE_FILE=$TRACE_FILE >> run_env.sh
+echo export TRACE_FILE=/dunedaq/pocket/trace_buffer >> run_env.sh
 echo "Build completed"


### PR DESCRIPTION
to allow high-speed memory tracing and access to the TRACE buffer file, TRACE_FILE needs to be set.
In lieu of the perfect solution, hardcoding the file plus instructions on the wiki will show a good starting example, and get developers started.