### PR TITLE
Plasorak/better image building

### DIFF
--- a/images/daq_application/daq_area_cvmfs/build_docker_image
+++ b/images/daq_application/daq_area_cvmfs/build_docker_image
@@ -10,7 +10,7 @@ DKR_TAG=${1}
 DKR_BASE_IMG=dunedaq/c8-minimal:latest
 set -e
 usage () {
-    echo "This utility builds docker images containing the necessary code for DAQ applications"
+    echo "This utility builds docker images containing the necessary code for DAQ applications from your source area \$\{DBT_AREA_ROOT\}=${DBT_AREA_ROOT}"
     echo "./build_docker_image image_name"
 }
 

--- a/images/daq_application/daq_area_cvmfs/build_docker_image
+++ b/images/daq_application/daq_area_cvmfs/build_docker_image
@@ -8,10 +8,22 @@ DST_AREA="${DKR_BUILD_HERE}/image"
 
 DKR_TAG=${1}
 DKR_BASE_IMG=dunedaq/c8-minimal:latest
+set -e
+usage () {
+    echo "This utility builds docker images containing the necessary code for DAQ applications"
+    echo "./build_docker_image image_name"
+}
 
 if [[ $# -ne 1 ]]; then
-    echo "ERROR: Wrong number of arguments: 1 expecgted, $# found."
+    echo "ERROR: Wrong number of arguments: 1 expected, $# found."
+    usage
     exit 2
+fi
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]
+then
+    usage
+    exit 0
 fi
 
 
@@ -68,3 +80,7 @@ DKR_VERSION=$(bash -c "source $DKR_BUILD_HERE/image/dbt-settings; echo \$DUNE_DA
 
 cp -a $DKR_BUILD_HERE/../common $DKR_BUILD_HERE
 docker buildx build --tag ${DKR_TAG}:${DKR_VERSION} $DKR_BUILD_HERE
+
+echo "------------------------------------------"
+echo "Image $DKR_TAG:$DKR_VERSION built!"
+echo "------------------------------------------"

--- a/images/daq_application/daq_area_cvmfs/harbor_push
+++ b/images/daq_application/daq_area_cvmfs/harbor_push
@@ -1,8 +1,20 @@
 #!/bin/bash
+set -e
+usage () {
+    echo "This utility pushes the image to harbor"
+    echo "./harbor_push image_name"
+}
 
 if [[ $# -ne 1 ]]; then
     echo "ERROR: Wrong number of arguments: 1 expected, $# found."
+    usage
     exit 2
+fi
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]
+then
+    usage
+    exit 0
 fi
 
 DOCKER_REPO="np04docker.cern.ch/dunedaq-local"

--- a/images/daq_application/daq_area_cvmfs/rebuild_work_area.sh
+++ b/images/daq_application/daq_area_cvmfs/rebuild_work_area.sh
@@ -19,7 +19,7 @@ echo "------------------------------------------"
 cd $DBT_AREA
 source ./dbt-env.sh
 dbt-workarea-env
-dbt-build.py -c
+dbt-build -c
 rm -rf build
 make_env_script.sh
 echo "------------------------------------------"

--- a/images/daq_application/daq_release_cvmfs/build_docker_image
+++ b/images/daq_application/daq_release_cvmfs/build_docker_image
@@ -3,10 +3,28 @@
 SH_SOURCE=${BASH_SOURCE[0]:-${(%):-%x}}
 DKR_BUILD_HERE=$(cd $(dirname ${SH_SOURCE}) && pwd)
 
+DUNEDAQ_RELEASE=$1
 
-DUNEDAQ_RELEASE="v2.10.2"
+set -e
+usage () {
+    echo "This utility builds docker images containing the necessary code for DAQ applications from a release."
+    echo "./build_docker_image RELEASE"
+    echo "(for example ./build_docker_image v3.0.0)"
+}
 
-DKR_TAG=pocket-daq-release-cvmfs
+if [[ $# -ne 1 ]]; then
+    echo "ERROR: Wrong number of arguments: 1 expected, $# found."
+    usage
+    exit 2
+fi
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]
+then
+    usage
+    exit 0
+fi
+
+DKR_TAG=daq-release
 DKR_VERSION=${DUNEDAQ_RELEASE}
 DKR_BASE_IMG=dunedaq/c8-minimal:latest
 
@@ -17,6 +35,7 @@ mkdir -p ${DST_AREA}
 
 DOCKER_OPTS="--user $(id -u):$(id -g) \
     -it \
+    -v ${HOME}/.spack:${HOME}/.spack \
     -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
     -v /cvmfs/dunedaq.opensciencegrid.org:/cvmfs/dunedaq.opensciencegrid.org \
     -v /cvmfs/dunedaq-development.opensciencegrid.org:/cvmfs/dunedaq-development.opensciencegrid.org"
@@ -43,3 +62,7 @@ echo "------------------------------------------"
 echo "Building $DKR_TAG:$DKR_VERSION docker image"
 echo "------------------------------------------"
 docker buildx build --tag $DKR_TAG:$DKR_VERSION $DKR_BUILD_HERE 
+
+echo "------------------------------------------"
+echo "Image $DKR_TAG:$DKR_VERSION built!"
+echo "------------------------------------------"

--- a/images/daq_application/daq_release_cvmfs/capture_release_env.sh
+++ b/images/daq_application/daq_release_cvmfs/capture_release_env.sh
@@ -18,7 +18,7 @@ setup_dbt dunedaq-${DUNEDAQ_RELEASE}
 echo "------------------------------------------"
 echo "Loading daq-release environment"
 echo "------------------------------------------"
-dbt-setup-release  dunedaq-${DUNEDAQ_RELEASE}-cs8
+dbt-setup-release  dunedaq-${DUNEDAQ_RELEASE}
 
 echo "------------------------------------------"
 echo "Capturing runtime environment"

--- a/images/daq_application/daq_release_cvmfs/harbor_push
+++ b/images/daq_application/daq_release_cvmfs/harbor_push
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+usage () {
+    echo "This utility pushes the image to harbor"
+    echo "./harbor_push image_name"
+}
+
+if [[ $# -ne 1 ]]; then
+    echo "ERROR: Wrong number of arguments: 1 expected, $# found."
+    usage
+    exit 2
+fi
+
+if [ "$1" = "-h" ] || [ "$1" = "--help" ]
+then
+    usage
+    exit 0
+fi
+
+DOCKER_REPO="np04docker.cern.ch/dunedaq-local"
+docker tag ${1} ${DOCKER_REPO}/${1}
+docker push ${DOCKER_REPO}/${1}
+


### PR DESCRIPTION
This is the second part of a PR that is merged already. Essentially this makes spacks work with daq_release image, and gives more explanatory names to the scripts:
 - `build_docker_image image-name` will create an image from the current environment (in daq_area_cvmfs)
 - `build_docker_image dunedaq-version` will create an image from a DUNE-DAQ release (in daq_release_cvmfs)
 - `harbor_push image-name:tag` pushes to Harbor repo at NP04.