### PR TITLE
add second database to influx to support both v3.1+ and v3.0- versions

### DIFF
--- a/manifests/opmon/influxdb.yaml
+++ b/manifests/opmon/influxdb.yaml
@@ -113,6 +113,23 @@ data:
         "influxdb.*.*.*.users.*.* measurement.test.injector.simulation.measurement.request.field"
       ]
 
+[[graphite]]
+      enabled = true
+      bind-address = ":2004"
+      database = "influxv3"
+      retention-policy = ""
+      protocol = "tcp"
+      batch-size = 5000
+      batch-pending = 10
+      batch-timeout = "1s"
+      consistency-level = "one"
+      separator = "."
+      udp-read-buffer = 0
+      templates = [
+        "influxv3.*.*.*.*.*.* measurement.test.injector.simulation.request.status.field",
+        "influxv3.*.*.*.users.*.* measurement.test.injector.simulation.measurement.request.field"
+      ]
+
     [[collectd]]
       enabled = false
       bind-address = ":25826"

--- a/manifests/opmon/influxdb.yaml
+++ b/manifests/opmon/influxdb.yaml
@@ -201,6 +201,18 @@ spec:
         envFrom:
         - secretRef:
             name: influxdb-secrets
+        volumeMounts:
+        - mountPath: /etc/influxdb/influxdb.conf
+          name: influxdb-config
+          subPath: influxdb.conf
+          readOnly: true
+        env:
+        - name: INFLUXDB_DB
+          value: "telegraf; CREATE DATABASE influxdb; CREATE DATABASE influxv3"
+      volumes:
+        - name: influxdb-config
+          configMap:
+            name: influxdb-config
 ---
 apiVersion: v1  
 kind: Service  

--- a/manifests/opmon/influxdb.yaml
+++ b/manifests/opmon/influxdb.yaml
@@ -113,7 +113,7 @@ data:
         "influxdb.*.*.*.users.*.* measurement.test.injector.simulation.measurement.request.field"
       ]
 
-[[graphite]]
+    [[graphite]]
       enabled = true
       bind-address = ":2004"
       database = "influxv3"


### PR DESCRIPTION
According to this [link](https://docs.influxdata.com/influxdb/v1.8/supported_protocols/graphite/) this PR should allow two different tables inside the same influxdb instance. 
I've yet to understand how to test it without breaking things.