### PR TITLE
Fix? for grafana configmap generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,10 +151,13 @@ opmon.local: erspostgres.local
 	--from-literal=GF_SECURITY_ADMIN_PASSWORD="${GF_SECURITY_ADMIN_PASSWORD}" ||:
 
 	$(KUBECTL) -n monitoring create configmap grafana-datasources \
-	--from-file=manifests/opmon/grafana/provisioning/
+	--from-file=manifests/opmon/grafana/datasources/
 
 	$(KUBECTL) -n monitoring create configmap grafana-dashboards \
 	--from-file=manifests/opmon/grafana/grafana-dashboards-develop/
+
+	$(KUBECTL) -n monitoring create configmap dashboard-provisioning \
+	--from-file=manifests/opmon/grafana/provisioning/
 
 	@>/dev/null 2>&1 $(KUBECTL) -n monitoring create secret generic influxdb-secrets \
 	--from-literal=INFLUXDB_CONFIG_PATH=/etc/influxdb/influxdb.conf \


### PR DESCRIPTION
I was having issues getting the grafana pod to start in my pocket installation. It was complaining about the missing "dashboard-provisioning" config map, and I didn't see any references to it in the Makefile. Adding these lines allowed Grafana to start, though I'm still getting `Failed to upgrade legacy queries Datasource named ${DS_INFLUXKAFKA} was not found` errors whenever I try to load dashboards.