### PR TITLE
update the grafana container

### DIFF
--- a/manifests/opmon/grafana.yaml
+++ b/manifests/opmon/grafana.yaml
@@ -16,8 +16,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: grafana/grafana:8.1.8
-        imagePullPolicy: Always
+        image: grafana/grafana-oss:9.4.3
         ports:
         - containerPort: 3000
           name: http-grafana

--- a/manifests/opmon/grafana/grafana.yaml
+++ b/manifests/opmon/grafana/grafana.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: grafana
-        image: grafana/grafana:8.1.8
+        image: grafana/grafana:9.4.3
         imagePullPolicy: Always
         ports:
         - containerPort: 3000


### PR DESCRIPTION
This brings us up to the current release.  I get some template errors in pocket under both 8.1.4 and 9.4.3, so I suspect they aren't related to the version change.