### PR TITLE
Provide a fairly generic alertmanager configmap

### DIFF
--- a/manifests/opmon/alertmanager/AlertManagerConfig.yaml
+++ b/manifests/opmon/alertmanager/AlertManagerConfig.yaml
@@ -1,0 +1,241 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: alertmanager-config
+  namespace: monitoring
+data:
+  config.yml: |-
+    global:
+      # ResolveTimeout is the time after which an alert is declared resolved
+      # if it has not been updated.
+      resolve_timeout: 5m
+
+      # The smarthost and SMTP sender used for mail notifications.
+      smtp_smarthost: 'smtp.gmail.com:587'
+      smtp_from: 'foo@bar.com'
+      # smtp_auth_username: 'foo@bar.com'
+      # smtp_auth_password: 'barfoo'
+
+      # The API URL to use for Slack notifications.
+      # slack_api_url: 'https://hooks.slack.com/services/abc123'
+
+      # # The auth token for Hipchat.
+      # hipchat_auth_token: '1234556789'
+      #
+      # # Alternative host for Hipchat.
+      # hipchat_url: 'https://hipchat.foobar.org/'
+
+    # # The directory from which notification templates are read.
+    templates:
+    - '/etc/alertmanager-templates/*.tmpl'
+
+    # The root route on which each incoming alert enters.
+    route:
+
+      # The labels by which incoming alerts are grouped together. For example,
+      # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
+      # be batched into a single group.
+
+      group_by: ['alertname', 'cluster', 'service']
+
+      # When a new group of alerts is created by an incoming alert, wait at
+      # least 'group_wait' to send the initial notification.
+      # This way ensures that you get multiple alerts for the same group that start
+      # firing shortly after another are batched together on the first
+      # notification.
+
+      group_wait: 30s
+
+      # When the first notification was sent, wait 'group_interval' to send a batch
+      # of new alerts that started firing for that group.
+
+      group_interval: 5m
+
+      # If an alert has successfully been sent, wait 'repeat_interval' to
+      # resend them.
+
+      #repeat_interval: 1m
+      repeat_interval: 15m
+
+      # A default receiver
+
+      # If an alert isn't caught by a route, send it to default.
+      receiver: default
+
+      # All the above attributes are inherited by all child routes and can
+      # overwritten on each.
+
+      # The child route trees.
+      routes:
+      # Send severity=slack alerts to slack.
+      - match:
+          severity: slack
+        receiver: slack_alert
+      - match:
+          severity: email
+       receiver: email_alert
+
+    receivers:
+    - name: 'default'
+      slack_configs:
+      - channel: '#devops'
+        text: '<!channel>{{ template "slack.devops.text" . }}'
+        send_resolved: true
+
+    - name: 'slack_alert'
+      slack_configs:
+      - channel: '#devops'
+        send_resolved: true
+
+        # # Whether or not to notify about resolved alerts.
+        # send_resolved: true
+        #
+        # # The Slack webhook URL.
+        # [ api_url: <string> | default = global.slack_api_url ]
+        #
+        # # The channel or user to send notifications to.
+        # channel: <tmpl_string>
+        #
+        # # API request data as defined by the Slack webhook API.
+        # [ color: <tmpl_string> | default = '{{ if eq .Status "firing" }}danger{{ else }}good{{ end }}' ]
+        # [ username: <tmpl_string> | default = '{{ template "slack.default.username" . }}'
+        # [ title: <tmpl_string> | default = '{{ template "slack.default.title" . }}' ]
+        # [ title_link: <tmpl_string> | default = '{{ template "slack.default.titlelink" . }}' ]
+        # [ icon_emoji: <tmpl_string> ]
+        # [ pretext: <tmpl_string> | default = '{{ template "slack.default.pretext" . }}' ]
+        # [ text: <tmpl_string> | default = '{{ template "slack.default.text" . }}' ]
+        # [ fallback: <tmpl_string> | default = '{{ template "slack.default.fallback" . }}' ]
+
+    - name: 'email_alert'
+      email_configs:
+      - to: 'foo@bar.com'
+
+
+    #
+    #
+    #
+    # global:
+    #   # The smarthost and SMTP sender used for mail notifications.
+    #   smtp_smarthost: 'localhost:25'
+    #   smtp_from: 'alertmanager@example.org'
+    #   smtp_auth_username: 'alertmanager'
+    #   smtp_auth_password: 'password'
+    #   # The auth token for Hipchat.
+    #   hipchat_auth_token: '1234556789'
+    #   # Alternative host for Hipchat.
+    #   hipchat_url: 'https://hipchat.foobar.org/'
+    #
+    # # The directory from which notification templates are read.
+    # templates:
+    # - '/etc/alertmanager/template/*.tmpl'
+    #
+    # # The root route on which each incoming alert enters.
+    # route:
+    #   # The labels by which incoming alerts are grouped together. For example,
+    #   # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
+    #   # be batched into a single group.
+    #   group_by: ['alertname', 'cluster', 'service']
+    #
+    #   # When a new group of alerts is created by an incoming alert, wait at
+    #   # least 'group_wait' to send the initial notification.
+    #   # This way ensures that you get multiple alerts for the same group that start
+    #   # firing shortly after another are batched together on the first
+    #   # notification.
+    #   group_wait: 30s
+    #
+    #   # When the first notification was sent, wait 'group_interval' to send a batch
+    #   # of new alerts that started firing for that group.
+    #   group_interval: 5m
+    #
+    #   # If an alert has successfully been sent, wait 'repeat_interval' to
+    #   # resend them.
+    #   repeat_interval: 3h
+    #
+    #   # A default receiver
+    #   receiver: team-X-mails
+    #
+    #   # All the above attributes are inherited by all child routes and can
+    #   # overwritten on each.
+    #
+    #   # The child route trees.
+    #   routes:
+    #   # This routes performs a regular expression match on alert labels to
+    #   # catch alerts that are related to a list of services.
+    #   - match_re:
+    #       service: ^(foo1|foo2|baz)$
+    #     receiver: team-X-mails
+    #     # The service has a sub-route for critical alerts, any alerts
+    #     # that do not match, i.e. severity != critical, fall-back to the
+    #     # parent node and are sent to 'team-X-mails'
+    #     routes:
+    #     - match:
+    #         severity: critical
+    #       receiver: team-X-pager
+    #   - match:
+    #       service: files
+    #     receiver: team-Y-mails
+    #
+    #     routes:
+    #     - match:
+    #         severity: critical
+    #       receiver: team-Y-pager
+    #
+    #   # This route handles all alerts coming from a database service. If there's
+    #   # no team to handle it, it defaults to the DB team.
+    #   - match:
+    #       service: database
+    #     receiver: team-DB-pager
+    #     # Also group alerts by affected database.
+    #     group_by: [alertname, cluster, database]
+    #     routes:
+    #     - match:
+    #         owner: team-X
+    #       receiver: team-X-pager
+    #     - match:
+    #         owner: team-Y
+    #       receiver: team-Y-pager
+    #
+    #
+    # # Inhibition rules allow to mute a set of alerts given that another alert is
+    # # firing.
+    # # We use this to mute any warning-level notifications if the same alert is
+    # # already critical.
+    # inhibit_rules:
+    # - source_match:
+    #     severity: 'critical'
+    #   target_match:
+    #     severity: 'warning'
+    #   # Apply inhibition if the alertname is the same.
+    #   equal: ['alertname', 'cluster', 'service']
+    #
+    #
+    # receivers:
+    # - name: 'team-X-mails'
+    #   email_configs:
+    #   - to: 'team-X+alerts@example.org'
+    #
+    # - name: 'team-X-pager'
+    #   email_configs:
+    #   - to: 'team-X+alerts-critical@example.org'
+    #   pagerduty_configs:
+    #   - service_key: <team-X-key>
+    #
+    # - name: 'team-Y-mails'
+    #   email_configs:
+    #   - to: 'team-Y+alerts@example.org'
+    #
+    # - name: 'team-Y-pager'
+    #   pagerduty_configs:
+    #   - service_key: <team-Y-key>
+    #
+    # - name: 'team-DB-pager'
+    #   pagerduty_configs:
+    #   - service_key: <team-DB-key>
+    # - name: 'team-X-hipchat'
+    #   hipchat_configs:
+    #   - auth_token: <auth_token>
+    #     room_id: 85
+    #     message_format: html
+    #     notify: true
+

--- a/manifests/opmon/prometheus/config-map.yaml
+++ b/manifests/opmon/prometheus/config-map.yaml
@@ -69,10 +69,21 @@ data:
       - /etc/prometheus/prometheus.rules
     alerting:
       alertmanagers:
-      - scheme: http
-        static_configs:
-        - targets:
-          - "alertmanager.monitoring.svc:9093"
+      - kubernetes_sd_configs:
+          - role: pod
+        tls_config:
+          ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_label_name]
+          regex: alertmanager
+          action: keep
+        - source_labels: [__meta_kubernetes_namespace]
+          regex: monitoring
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_container_port_number]
+          regex:
+          action: drop
 
     scrape_configs:
       - job_name: 'node-exporter'


### PR DESCRIPTION
If you load the alertmanager yamls, this one should now permit starting the container.  Folks will need to customize it to their needs, but at least the container will now start.