### PR TITLE
Wait for Kafka to start with Init containers on the consumers

### DIFF
--- a/manifests/ers/ers-dbwriter.yaml
+++ b/manifests/ers/ers-dbwriter.yaml
@@ -12,7 +12,11 @@ spec:
     metadata:
       labels:
         app: erskafka
-    spec:
+    speci:
+      initContainers:
+      - name: wait-for-kafka
+        image: busybox:1.28
+        command: ['sh','-c', 'until nslookup kafka-svc.kafka-kraft.svc.cluster.local; do echo waiting for kafka to run; sleep 1; done']
       containers:
       - image: ghcr.io/dune-daq/pocket-ersdbwriter:latest
         name: erskafka

--- a/manifests/ers/ers-dbwriter.yaml
+++ b/manifests/ers/ers-dbwriter.yaml
@@ -12,7 +12,7 @@ spec:
     metadata:
       labels:
         app: erskafka
-    speci:
+    spec:
       initContainers:
       - name: wait-for-kafka
         image: busybox:1.28

--- a/manifests/opmon/kafka2influx.yaml
+++ b/manifests/opmon/kafka2influx.yaml
@@ -13,11 +13,10 @@ spec:
       labels:
         app: kafka2influx
     spec:
-
       initContainers:
       - image: busybox:1.28
         name: wait-for-kafka2
-        command: ['sh', '-c', 'until nslookup kafka-svc.kafka-kraft.svc.cluster.local; do echo waiting for kafka; sleep 1, done']
+        command: ['sh', '-c', 'until nslookup kafka-svc.kafka-kraft.svc.cluster.local; do echo waiting for kafka; sleep 1; done']
       containers:
       - image: dunedaq/pocket-opmon-microservice:1.0
         name: kafka2influx

--- a/manifests/opmon/kafka2influx.yaml
+++ b/manifests/opmon/kafka2influx.yaml
@@ -13,6 +13,11 @@ spec:
       labels:
         app: kafka2influx
     spec:
+
+      initContainers:
+      - image: busybox:1.28
+        name: wait-for-kafka2
+        command: ['sh', '-c', 'until nslookup kafka-svc.kafka-kraft.svc.cluster.local; do echo waiting for kafka; sleep 1, done']
       containers:
       - image: dunedaq/pocket-opmon-microservice:1.0
         name: kafka2influx


### PR DESCRIPTION
When initialising make setup.local, the  erskafka and kafka2influx pods would start but because kafka had not initialised yet, they would have to restart multiple times until getting created. This makes the pods wait until the kafka service is up and running before beginning the initialisation process of these pods. 