### PR TITLE
Removed unused cvmfs path, and mounted postgres db path

### DIFF
--- a/local/kind.config.yml
+++ b/local/kind.config.yml
@@ -22,10 +22,8 @@ nodes:
   #  containerPath: /pocket
   - hostPath: ./share/dqm
     containerPath: /scratch/dqm-db
-  - hostPath: /cvmfs/dunedaq.opensciencegrid.org
-    containerPath: /cvmfs/dunedaq.opensciencegrid.org
-  - hostPath: /cvmfs/dunedaq-development.opensciencegrid.org
-    containerPath: /cvmfs/dunedaq-development.opensciencegrid.org
+  - hostPath: ./share/postgres
+    containerPath: /scratch/kube/postgres
   extraPortMappings:
   - # proxy server
     containerPort: 31000


### PR DESCRIPTION
Removed unused cvmfs mounts which caused issues of not creating kind cluster on some machines. Followed by mounting the postgres db to maintain data persistence 